### PR TITLE
SQL query optimization

### DIFF
--- a/Koha/Plugin/Com/Liliputech/RecommenderEngine.pm
+++ b/Koha/Plugin/Com/Liliputech/RecommenderEngine.pm
@@ -226,15 +226,15 @@ sub updateSQL() {
     my $marcflavour = C4::Context->preference('marcflavour');
     my $marcdata;
     if ($marcflavour eq 'UNIMARC') {
-        $marcdata = "ExtractValue(metadata,'//datafield[\@tag=\"200\"]/subfield[\@code=\"a\"]') title,
-		ifnull(ExtractValue(metadata,'//datafield[\@tag=\"200\"]/subfield[\@code=\"d\"]'),\"\") subtitle,
-		ifnull(ExtractValue(metadata,'//datafield[\@tag=\"200\"]/subfield[\@code=\"h\"]'),\"\") partnumber,
-		ifnull(ExtractValue(metadata,'//datafield[\@tag=\"200\"]/subfield[\@code=\"f\"]'),\"\") author,";
+        $marcdata = "biblio.title,
+		coalesce(ExtractValue(metadata,'//datafield[\@tag=\"200\"]/subfield[\@code=\"d\"]'),\"\") subtitle,
+		coalesce(ExtractValue(metadata,'//datafield[\@tag=\"200\"]/subfield[\@code=\"h\"]'),\"\") partnumber,
+		biblio.author,";
     } elsif ($marcflavour eq 'MARC21') {
-        $marcdata = "ExtractValue(metadata,'//datafield[\@tag=\"245\"]/subfield[\@code=\"a\"]') title,
-		ifnull(ExtractValue(metadata,'//datafield[\@tag=\"245\"]/subfield[\@code=\"b\"]'),\"\") subtitle,
-		ifnull(ExtractValue(metadata,'//datafield[\@tag=\"245\"]/subfield[\@code=\"n\"]'),\"\") partnumber,
-		ifnull(ExtractValue(metadata,'//datafield[\@tag=\"245\"]/subfield[\@code=\"c\"]'),\"\") author,";
+        $marcdata = "biblio.title,
+		coalesce(ExtractValue(metadata,'//datafield[\@tag=\"245\"]/subfield[\@code=\"b\"]'),\"\") subtitle,
+		coalesce(ExtractValue(metadata,'//datafield[\@tag=\"245\"]/subfield[\@code=\"n\"]'),\"\") partnumber,
+		biblio.author,";
     }
     my $template = $self->get_template( { file => 'savedsql.tt' } );
     $template->param( 	'marcdata' => $marcdata,

--- a/Koha/Plugin/Com/Liliputech/RecommenderEngine/savedsql.tt
+++ b/Koha/Plugin/Com/Liliputech/RecommenderEngine/savedsql.tt
@@ -15,3 +15,4 @@ join (
     limit [% recordnumber %]
     ) suggestions
 on biblio_metadata.biblionumber=suggestions.biblionumber
+join biblio ON biblio_metadata.biblionumber = biblio.biblionumber


### PR DESCRIPTION
This commit changes ifnull to coalesce as ifnull is mysqlism

Also it takes biblio.title and biblio.author as data instead of fetching it from marcxml - it is a bit faster. Tested on system with 1.25 old issues, 10 years back and limit 1000.

Old SQl took 0.435 s
New 0.343 s

When this bug is pushed to Koha, it will be possible to remove two other ExtractValue calls:

https://bugs.koha-community.org/bugzilla3/show_bug.cgi?id=11529